### PR TITLE
Optimize experiment thumbnails

### DIFF
--- a/apps/web/src/app/(home)/sections/experiments/experiments-list.tsx
+++ b/apps/web/src/app/(home)/sections/experiments/experiments-list.tsx
@@ -70,7 +70,6 @@ export function ExperimentsList({ items }: { items: Experiment[] }) {
                   fill
                   sizes="(max-width: 1280px) 192px, 256px"
                   className="object-cover"
-                  unoptimized
                 />
               ) : (
                 <PreviewFallback label={experiment.name} />

--- a/apps/web/src/app/experiments/page.tsx
+++ b/apps/web/src/app/experiments/page.tsx
@@ -53,7 +53,6 @@ export default async function ExperimentsPage() {
                     fill
                     sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className="object-cover transition-opacity duration-300 group-hover:opacity-80"
-                    unoptimized
                   />
                 ) : (
                   <div className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
Drops `unoptimized` from the experiment `next/image` usages (homepage section + `/experiments` grid).

The experiment domains (`experiments.matiasgf.dev`, `*.vercel.app`) are already in `next.config` `remotePatterns`, so Next/Vercel now serves resized WebP sized to the grid/`sizes` instead of the raw **1–3.5 MB PNG** screenshots — a big payload + LCP win.

No visual change; same images, smaller bytes. Typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)