### PR TITLE
fix(experiments): show human-readable title instead of slug

### DIFF
--- a/apps/experiments-server/src/experiment-config-schema.ts
+++ b/apps/experiments-server/src/experiment-config-schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
 
 export const experimentConfigSchema = z.object({
-  name: z.string().describe('The unique identifier/name of the experiment'),
+  name: z.string().describe('The unique identifier/slug of the experiment (used for the folder name and URL)'),
+  title: z.string().describe('The human-readable display name shown in lists'),
   description: z.string().describe('A brief description of the experiment'),
   tags: z.array(z.string()).describe('Keywords associated with the experiment'),
   list: z.boolean().describe('Whether to include this experiment in generated lists'),

--- a/apps/web/src/app/(home)/sections/experiments/experiments-list.tsx
+++ b/apps/web/src/app/(home)/sections/experiments/experiments-list.tsx
@@ -43,13 +43,13 @@ export function ExperimentsList({ items }: { items: Experiment[] }) {
               target="_blank"
               rel="noopener noreferrer"
               className="absolute inset-0 z-10"
-              aria-label={experiment.name}
+              aria-label={experiment.title}
             />
 
             {/* Text content */}
             <div className="flex-1 py-6 px-6 flex flex-col gap-2 min-w-0">
               <h3 className="font-serif text-4xl xl:text-5xl leading-tight">
-                {experiment.name}
+                {experiment.title}
               </h3>
               <p className="font-serif text-sm text-foreground/60 leading-snug">
                 {experiment.description}
@@ -66,14 +66,14 @@ export function ExperimentsList({ items }: { items: Experiment[] }) {
               {experiment.preview ? (
                 <Image
                   src={experiment.preview}
-                  alt={experiment.name}
+                  alt={experiment.title}
                   fill
                   sizes="(max-width: 1280px) 192px, 256px"
                   className="object-cover"
                   unoptimized
                 />
               ) : (
-                <PreviewFallback label={experiment.name} />
+                <PreviewFallback label={experiment.title} />
               )}
             </div>
           </div>

--- a/apps/web/src/app/experiments/page.tsx
+++ b/apps/web/src/app/experiments/page.tsx
@@ -49,7 +49,7 @@ export default async function ExperimentsPage() {
                 {experiment.preview ? (
                   <Image
                     src={experiment.preview}
-                    alt={experiment.name}
+                    alt={experiment.title}
                     fill
                     sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className="object-cover transition-opacity duration-300 group-hover:opacity-80"
@@ -58,7 +58,7 @@ export default async function ExperimentsPage() {
                 ) : (
                   <div className="flex h-full w-full items-center justify-center">
                     <span className="font-sans text-xs tracking-widest uppercase text-foreground/30">
-                      {experiment.name}
+                      {experiment.title}
                     </span>
                   </div>
                 )}
@@ -66,7 +66,7 @@ export default async function ExperimentsPage() {
 
               {/* Meta */}
               <h2 className="mt-4 font-serif text-2xl leading-tight">
-                {experiment.name}
+                {experiment.title}
               </h2>
               <p className="mt-1 font-serif text-sm text-foreground/60 leading-snug">
                 {experiment.description}

--- a/apps/web/src/lib/experiments.ts
+++ b/apps/web/src/lib/experiments.ts
@@ -13,7 +13,10 @@ export const EXPERIMENTS_BASE = (
 
 /** Raw entry shape as emitted by experiments-server `generateExperimentsManifest`. */
 interface ManifestEntry {
+  /** Unique identifier/slug, used for the folder name and URL (e.g. "earth"). */
   name: string;
+  /** Human-readable display name. Optional for backwards-compat with older manifests. */
+  title?: string;
   description: string;
   tags: string[];
   list: boolean;
@@ -28,7 +31,10 @@ interface Manifest {
 
 /** Normalized experiment used across the web app. */
 export interface Experiment {
+  /** Unique identifier/slug, e.g. "earth". */
   name: string;
+  /** Human-readable display name, e.g. "Earth with a realistic atmosphere". */
+  title: string;
   description: string;
   tags: string[];
   /** Joined tags for display, e.g. "three.js · webgl". */
@@ -42,6 +48,8 @@ export interface Experiment {
 function normalize(entry: ManifestEntry): Experiment {
   return {
     name: entry.name,
+    // Fall back to the slug if an older manifest has no title yet.
+    title: entry.title || entry.name,
     description: entry.description,
     tags: entry.tags ?? [],
     tagsLabel: (entry.tags ?? []).join(" · "),

--- a/packages/experiments/earth/experiment-config.json
+++ b/packages/experiments/earth/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "earth",
-  "description": "Earth with a realistic atmosphere",
+  "title": "Earth with a realistic atmosphere",
+  "description": "",
   "tags": ["three.js", "webgl"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/ambient-occlusion/experiment-config.json
+++ b/packages/experiments/ray-marching/ambient-occlusion/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "ray-marching-ambient-occlusion",
-  "description": "Fluid sim shader",
+  "title": "Fluid sim shader",
+  "description": "",
   "tags": ["three.js", "webgl", "shader"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/boolean-operations/experiment-config.json
+++ b/packages/experiments/ray-marching/boolean-operations/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "ray-marching-boolean-operations",
-  "description": "A ray marching renderer with boolean operations",
+  "title": "A ray marching renderer with boolean operations",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/reflections/experiment-config.json
+++ b/packages/experiments/ray-marching/reflections/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "ray-marching-reflections",
-  "description": "A ray marching renderer with reflections",
+  "title": "A ray marching renderer with reflections",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/simple/experiment-config.json
+++ b/packages/experiments/ray-marching/simple/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "ray-marching-simple",
-  "description": "A ray marching renderer",
+  "title": "A ray marching renderer",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/voxels-campfire/experiment-config.json
+++ b/packages/experiments/ray-marching/voxels-campfire/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "voxels-campfire",
-  "description": "A raymarching campfire scene",
+  "title": "A raymarching campfire scene",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/voxels-lava-lamp/experiment-config.json
+++ b/packages/experiments/ray-marching/voxels-lava-lamp/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "voxels-lava-lamp",
-  "description": "A raymarching lava lamp",
+  "title": "A raymarching lava lamp",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/ray-marching/voxels/experiment-config.json
+++ b/packages/experiments/ray-marching/voxels/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "voxels",
-  "description": "A voxel raymarching renderer",
+  "title": "A voxel raymarching renderer",
+  "description": "",
   "tags": ["three.js", "ray-marching"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/shaders/basement-logo/experiment-config.json
+++ b/packages/experiments/shaders/basement-logo/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "basement-logo",
-  "description": "Basement shader",
+  "title": "Basement shader",
+  "description": "",
   "tags": ["three.js", "webgl", "shader"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/shaders/fluid/experiment-config.json
+++ b/packages/experiments/shaders/fluid/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "shaders-fluid",
-  "description": "Fluid sim shader",
+  "title": "Fluid sim shader",
+  "description": "",
   "tags": ["three.js", "webgl", "shader"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/shaders/plants/experiment-config.json
+++ b/packages/experiments/shaders/plants/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "shaders-plants",
-  "description": "Grow plants with code!",
+  "title": "Grow plants with code!",
+  "description": "",
   "tags": ["three.js", "webgl", "shader"],
   "list": true,
   "include": "dist"

--- a/packages/experiments/shaders/vercel-fluid-logo/experiment-config.json
+++ b/packages/experiments/shaders/vercel-fluid-logo/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "vercel-fluid-logo",
-  "description": "Vercel logo with fluid simulation",
+  "title": "Vercel logo with fluid simulation",
+  "description": "",
   "tags": ["three.js", "webgl", "shader"],
   "list": true,
   "include": "out"

--- a/packages/experiments/simple-scene/experiment-config.json
+++ b/packages/experiments/simple-scene/experiment-config.json
@@ -1,6 +1,7 @@
 {
   "name": "simple-scene",
-  "description": "A simple scene with a cube and a sphere",
+  "title": "A simple scene with a cube and a sphere",
+  "description": "",
   "tags": ["three.js", "webgl"],
   "list": true,
   "include": "dist"


### PR DESCRIPTION
## Problem
On the homepage Experiments section (and the `/experiments` grid), each experiment's **title was the raw slug** (e.g. `shaders-plants`, `ray-marching-simple`), while the real human-readable text lived in the `description` field.

The experiment config schema only had `name` (a slug, used for the folder name + URL) and `description` — there was no dedicated display name, and the UI used `name` as the heading.

## Change
- **Schema** (`experiment-config-schema.ts`): add a `title` field (human-readable display name); clarify that `name` is the slug/identifier.
- **Configs** (13 × `experiment-config.json`): add `title` populated from the existing `description`, and blank out `description` (to be filled in later).
- **Web** (`lib/experiments.ts`): expose `title` on the normalized `Experiment` (falls back to the slug for older manifests that predate this field).
- **Web UI** (`experiments-list.tsx`, `experiments/page.tsx`): render `title` for headings, `alt` text, aria-labels and the no-preview fallback. `name` is still used as the React key and for the experiment URL.

Example card before → after:

```
shaders-plants                 →   Grow plants with code!
Grow plants with code!             (description now blank)
```

## Notes
- The homepage/grid fetch a **remote** manifest (`experiments-manifest.json`). The manifest is generated by `apps/experiments-server` (it spreads the full config, so `title` flows through automatically). The new titles appear once the experiments-server is rebuilt/redeployed; until then the web falls back to the slug, so nothing breaks in the meantime.
- `tsc --noEmit` passes for both `apps/web` and `apps/experiments-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)